### PR TITLE
Change/add inputs for Resources and ClientClaims

### DIFF
--- a/src/app/api/gen/models.ts
+++ b/src/app/api/gen/models.ts
@@ -119,8 +119,14 @@ export interface Resource {
     required?: boolean;
     emphasize?: boolean;
     showInDiscoveryDocument?: boolean;
+    secrets?: Array<ApiSecret>;
     claims?: Array<ResourceClaim>;
     managers?: Array<ResourceManager>;
+}
+
+export interface ApiSecret {
+    id?: number;
+    value?: string;
 }
 
 export interface ResourceManager {

--- a/src/app/api/gen/models.ts
+++ b/src/app/api/gen/models.ts
@@ -119,6 +119,7 @@ export interface Resource {
     required?: boolean;
     emphasize?: boolean;
     showInDiscoveryDocument?: boolean;
+    scopes?: string;
     userClaims?: string;
     secrets?: Array<ApiSecret>;
     claims?: Array<ResourceClaim>;

--- a/src/app/api/gen/models.ts
+++ b/src/app/api/gen/models.ts
@@ -119,6 +119,7 @@ export interface Resource {
     required?: boolean;
     emphasize?: boolean;
     showInDiscoveryDocument?: boolean;
+    userClaims?: string;
     secrets?: Array<ApiSecret>;
     claims?: Array<ResourceClaim>;
     managers?: Array<ResourceManager>;

--- a/src/app/api/gen/resource.service.ts
+++ b/src/app/api/gen/resource.service.ts
@@ -7,7 +7,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiSettings } from '../api-settings';
 import { GeneratedService } from './_service';
-import { ChangedResource, NewResource, Resource, SearchParams } from './models';
+import { ChangedResource, NewResource, Resource, ApiSecret, SearchParams } from './models';
 
 @Injectable()
 export class GeneratedResourceService extends GeneratedService {
@@ -34,5 +34,8 @@ export class GeneratedResourceService extends GeneratedService {
     }
     public generateInvite(id: number): Observable<any> {
       return this.http.put<any>(this.api.url + '/api/resource/' + id + '/code', {});
+    }
+    public generateSecret(id: number): Observable<ApiSecret> {
+        return this.http.put<ApiSecret>(this.api.url + '/api/resource/' + id + '/secret', {});
     }
 }

--- a/src/app/ui/api-browser/api-browser.component.html
+++ b/src/app/ui/api-browser/api-browser.component.html
@@ -34,8 +34,8 @@
       <tbody>
         <tr *ngFor="let r of identityResources | async">
           <td class="text-left"><span *ngIf="r.default" aria-label="public">&#x2713;</span></td>
-          <td class="text-left">{{r.name}}</td>
-          <td class="text-left text-muted">{{r.description}}</td>
+          <td class="text-left">{{r.scopes}}</td>
+          <td class="text-left text-muted">{{r.userClaims}}</td>
         </tr>
       </tbody>
     </table>

--- a/src/app/ui/api-editor/api-editor.component.html
+++ b/src/app/ui/api-editor/api-editor.component.html
@@ -43,6 +43,18 @@
 
         </app-collapse-panel>
 
+        <app-collapse-panel label="Api Secrets">
+
+          <button type="button" class="btn btn-secondary" (click)="newSecret()">Generate New Secret</button>
+          <p class="form-text text-muted"><small>
+            Secret only visible immediately after generation.
+          </small></p>
+
+          <app-input-list label="" field="secrets" [control]="form.controls.secrets">
+          </app-input-list>
+
+        </app-collapse-panel>
+
         <div class="text-center">
 
           <app-error-list [errors]="errors"></app-error-list>

--- a/src/app/ui/api-editor/api-editor.component.html
+++ b/src/app/ui/api-editor/api-editor.component.html
@@ -18,6 +18,11 @@
             maxlength="100" [control]="form.controls.displayName">
           </app-input-text>
 
+          <app-input-text label="User Claims" field="userClaims"
+            maxlength="200" [control]="form.controls.userClaims">
+            Some user claims must be set by an administrator.
+          </app-input-text>
+
           <app-input-checkbox label="Public Resource" field="default"
             [control]="form.controls.default">
             By default, only clients you manage can request this resource.

--- a/src/app/ui/api-editor/api-editor.component.html
+++ b/src/app/ui/api-editor/api-editor.component.html
@@ -18,6 +18,11 @@
             maxlength="100" [control]="form.controls.displayName">
           </app-input-text>
 
+          <app-input-text label="Scopes" field="scopes"
+            maxlength="200" [control]="form.controls.scopes">
+            Prefix additional scopes with the resource name.
+          </app-input-text>
+
           <app-input-text label="User Claims" field="userClaims"
             maxlength="200" [control]="form.controls.userClaims">
             Some user claims must be set by an administrator.

--- a/src/app/ui/api-editor/api-editor.component.ts
+++ b/src/app/ui/api-editor/api-editor.component.ts
@@ -2,7 +2,7 @@
 // Released under a MIT (SEI) license. See LICENSE.md in the project root.
 
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { Resource, ResourceTypeEnum } from 'src/app/api/gen/models';
+import { Resource, ResourceTypeEnum, ApiSecret } from 'src/app/api/gen/models';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { BaseComponent } from '../base.component';
 import { ResourceService } from 'src/app/api/resource.service';
@@ -66,8 +66,8 @@ export class ApiEditorComponent extends BaseComponent implements OnInit {
       default: [resource.default],
       enabled: [{ value: resource.enabled, disabled: !this.privileged}],
       type: [ResourceTypeEnum.api],
-      managers: [resource.managers]
-
+      managers: [resource.managers],
+      secrets: [ resource.secrets ]
     });
   }
 
@@ -88,6 +88,16 @@ export class ApiEditorComponent extends BaseComponent implements OnInit {
 
     );
 
+  }
+
+  newSecret() {
+    this.subs.push(
+      this.resourceSvc.generateSecret(this.resource.id).subscribe(
+        (secret: ApiSecret) => {
+          this.form.controls.secrets.value.push(secret);
+        }
+      )
+    );
   }
 
   newInvite() {

--- a/src/app/ui/api-editor/api-editor.component.ts
+++ b/src/app/ui/api-editor/api-editor.component.ts
@@ -63,6 +63,7 @@ export class ApiEditorComponent extends BaseComponent implements OnInit {
       id: [resource.id],
       name: [resource.name, Validators.required],
       displayName: [resource.displayName],
+      scopes: [resource.scopes],
       userClaims: [resource.userClaims],
       default: [resource.default],
       enabled: [{ value: resource.enabled, disabled: !this.privileged}],

--- a/src/app/ui/api-editor/api-editor.component.ts
+++ b/src/app/ui/api-editor/api-editor.component.ts
@@ -63,6 +63,7 @@ export class ApiEditorComponent extends BaseComponent implements OnInit {
       id: [resource.id],
       name: [resource.name, Validators.required],
       displayName: [resource.displayName],
+      userClaims: [resource.userClaims],
       default: [resource.default],
       enabled: [{ value: resource.enabled, disabled: !this.privileged}],
       type: [ResourceTypeEnum.api],

--- a/src/app/ui/client-editor/client-editor.component.html
+++ b/src/app/ui/client-editor/client-editor.component.html
@@ -145,10 +145,9 @@
           <app-input-text label="Prefix" field="clientClaimPrefix"
             maxlength="10" [control]="form.controls.clientClaimsPrefix"></app-input-text>
 
-          <app-input-list label="Claims" field="claims"
+          <app-input-keyvalue label="Claims" field="claims"
             maxlength="50" [control]="form.controls.claims">
-            Format: key = value
-          </app-input-list>
+          </app-input-keyvalue>
 
         </app-collapse-panel>
 

--- a/src/app/ui/client-editor/client-editor.component.html
+++ b/src/app/ui/client-editor/client-editor.component.html
@@ -145,7 +145,7 @@
           <app-input-text label="Prefix" field="clientClaimPrefix"
             maxlength="10" [control]="form.controls.clientClaimsPrefix"></app-input-text>
 
-          <app-input-keyvalue label="Claims" field="claims"
+          <app-input-keyvalue label="Claims" field="claims" keyname="type"
             maxlength="50" [control]="form.controls.claims">
           </app-input-keyvalue>
 

--- a/src/app/ui/input-keyvalue/input-keyvalue.component.html
+++ b/src/app/ui/input-keyvalue/input-keyvalue.component.html
@@ -1,0 +1,31 @@
+<div *ngIf="control" class="form-group mb-4">
+
+  <label [for]="field">{{label}}</label>
+
+  <div class="input-group mb-2">
+    <input type="text" class="form-control mr-1" [id]="keyfield"
+      [placeholder]="keyplaceholder" [maxlength]="maxlength"
+      autocomplete="off" [formControl]="keyinput" />
+    <input type="text" class="form-control" [id]="valuefield"
+      [placeholder]="valueplaceholder" [maxlength]="maxlength"
+      autocomplete="off" [formControl]="valueinput" />
+    <div class="input-group-append">
+      <button class="btn btn-outline-secondary" type="button"
+        [disabled]="!keyinput.value?.trim() || !valueinput.value?.trim()" (click)="addPair()" aria-label="add key value pair to list">+</button>
+    </div>
+  </div>
+  <small class="form-text text-muted">
+    <ng-content></ng-content>
+  </small>
+
+
+  <div *ngFor="let item of control.value">
+    <button type="button" class="btn btn-outline-secondary btn-sm mr-2"
+      aria-label="toggle remove undo" (click)="removePair(item)">
+      {{item.deleted ? "&#x27f2;" : "&#x2717;"}}
+    </button>
+    <span *ngIf="item.deleted" aria-label="list item"><del>{{getPair(item)}}</del></span>
+    <span *ngIf="!item.deleted" aria-label="list item">{{getPair(item)}}</span>
+  </div>
+
+</div>

--- a/src/app/ui/input-keyvalue/input-keyvalue.component.ts
+++ b/src/app/ui/input-keyvalue/input-keyvalue.component.ts
@@ -13,6 +13,7 @@ export class InputKeyValueComponent implements OnInit {
   @Input() label = '';
   @Input() field = '';
   @Input() keyplaceholder = 'Key';
+  @Input() keyname = 'key';
   @Input() valueplaceholder = 'Value';
   @Input() maxlength = 100;
   @Input() control: AbstractControl;
@@ -31,7 +32,7 @@ export class InputKeyValueComponent implements OnInit {
   }
 
   getPair(item: ListPair): string {
-    return `${item.type?.trim()} = ${item.value?.trim()}`;
+    return `${item[this.keyname]?.trim()} = ${item.value?.trim()}`;
   }
 
   addPair() {
@@ -55,7 +56,6 @@ export class InputKeyValueComponent implements OnInit {
 
 export interface ListPair {
   id?: string | number;
-  type?: string; // IdentityServer uses 'Type' as 'Key'
   value?: string;
   deleted?: boolean;
 }

--- a/src/app/ui/input-keyvalue/input-keyvalue.component.ts
+++ b/src/app/ui/input-keyvalue/input-keyvalue.component.ts
@@ -1,0 +1,61 @@
+// Copyright 2020 Carnegie Mellon University. 
+// Released under a MIT (SEI) license. See LICENSE.md in the project root. 
+
+import { Component, OnInit, Input } from '@angular/core';
+import { AbstractControl, FormControl } from '@angular/forms';
+
+@Component({
+  selector: 'app-input-keyvalue',
+  templateUrl: './input-keyvalue.component.html',
+  styleUrls: ['./input-keyvalue.component.scss']
+})
+export class InputKeyValueComponent implements OnInit {
+  @Input() label = '';
+  @Input() field = '';
+  @Input() keyplaceholder = 'Key';
+  @Input() valueplaceholder = 'Value';
+  @Input() maxlength = 100;
+  @Input() control: AbstractControl;
+  keyfield = '';
+  valuefield = '';
+  items: Array<ListPair> = [];
+  keyinput = new FormControl('');
+  valueinput = new FormControl('');
+  
+  constructor() { 
+  }
+
+  ngOnInit(): void {
+    this.keyfield = this.field+'Key';
+    this.valuefield = this.field+'Value';
+  }
+
+  getPair(item: ListPair): string {
+    return `${item.type?.trim()} = ${item.value?.trim()}`;
+  }
+
+  addPair() {
+    this.control.value.push(
+      { 
+        type: this.keyinput.value,
+        value: this.valueinput.value
+      }
+    );
+    this.control.markAsDirty();
+    this.keyinput.reset();
+    this.valueinput.reset();
+  }
+
+  removePair(item: ListPair) {
+    item.deleted = !item.deleted;
+    this.control.markAsDirty();
+  }
+
+}
+
+export interface ListPair {
+  id?: string | number;
+  type?: string; // IdentityServer uses 'Type' as 'Key'
+  value?: string;
+  deleted?: boolean;
+}

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -39,6 +39,7 @@ import { ProfileMergeComponent } from './profile-merge/profile-merge.component';
 import { UnauthComponent } from './unauth/unauth.component';
 import { HomeComponent } from './home/home.component';
 import { AccountMailerComponent } from './account-mailer/account-mailer.component';
+import { InputKeyValueComponent } from './input-keyvalue/input-keyvalue.component';
 @NgModule({
   declarations: [ProfileComponent, TotpComponent, ClientEditorComponent, ResourceNavComponent,
     ApiEditorComponent, ApiBrowserComponent, ClientBrowserComponent, AccountBrowserComponent, AccountEditorComponent,
@@ -46,7 +47,7 @@ import { AccountMailerComponent } from './account-mailer/account-mailer.componen
     InputTextComponent, EnlistManagerComponent, ConfirmButtonComponent, BackButtonComponent, AccountImportComponent,
     OverrideCodeComponent, SpacesPipe, ErrorListComponent,
     ProfileCredsComponent, ProfileEditComponent, ProfilePasswordComponent, ProfileEmailComponent, ProfileMergeComponent,
-    UnauthComponent, HomeComponent, AccountMailerComponent
+    UnauthComponent, HomeComponent, AccountMailerComponent, InputKeyValueComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
Goes with change to Identity: https://github.com/cmu-sei/Identity/pull/8

- Added functionally for ApiSecrets similar to ClientSecrets
- User can add multiple secrets to a resource through UI
- New Resource field for adding multiple UserClaims
- New Resource field for adding multiple Scopes
- New UI Component for adding key/value pairs in object form for Clients